### PR TITLE
OCTOPUS-397: header change for ansible/support

### DIFF
--- a/ansible/support/tasks/main.yml
+++ b/ansible/support/tasks/main.yml
@@ -135,7 +135,8 @@
         url: "{{ openshift_machine_config_url }}"
         dest: /var/www/html/worker.ign
         validate_certs: false
-        headers: "Accept: application/vnd.coreos.ignition+json;version=3.2.0"
+        headers:
+          "Accept": "application/vnd.coreos.ignition+json;version=3.2.0"
       environment:
         https_proxy: http://{{ vpc_support_server_ip }}:3128
 


### PR DESCRIPTION
header is changed in tasks/main.yml for ansible/support