### PR TITLE
OCTOPUS-650: Changes made to exclude creation of the Transit Gateway related activities by default

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -54,17 +54,18 @@ module "vpc_support" {
   depends_on = [module.checks]
   source     = "./modules/1_vpc_support"
 
-  vpc_name                      = var.vpc_name
-  vpc_region                    = var.vpc_region
-  vpc_zone                      = var.vpc_zone
-  public_key                    = var.public_key
-  public_key_file               = var.public_key_file
-  skip_vpc_key                  = var.skip_vpc_key
-  openshift_api_url             = var.openshift_api_url
-  powervs_machine_cidr          = var.powervs_machine_cidr
-  vpc_supp_public_ip            = var.vpc_supp_public_ip
-  override_transit_gateway_name = var.override_transit_gateway_name
-  mac_tags                      = var.mac_tags
+  vpc_name              = var.vpc_name
+  vpc_region            = var.vpc_region
+  vpc_zone              = var.vpc_zone
+  public_key            = var.public_key
+  public_key_file       = var.public_key_file
+  skip_vpc_key          = var.skip_vpc_key
+  openshift_api_url     = var.openshift_api_url
+  powervs_machine_cidr  = var.powervs_machine_cidr
+  vpc_supp_public_ip    = var.vpc_supp_public_ip
+  setup_transit_gateway = var.setup_transit_gateway
+  transit_gateway_name  = var.transit_gateway_name
+  mac_tags              = var.mac_tags
 }
 
 ### Prepares the PowerVS workspace for Day-2 Workers
@@ -119,12 +120,13 @@ module "transit_gateway" {
   depends_on = [module.pvs_prepare]
   source     = "./modules/3_transit_gateway"
 
-  cluster_id                    = local.cluster_id
-  vpc_name                      = var.vpc_name
-  vpc_crn                       = module.vpc_support.vpc_crn
-  transit_gateway_id            = module.vpc_support.transit_gateway_id
-  override_transit_gateway_name = var.override_transit_gateway_name
-  powervs_crn                   = module.pvs_prepare.powervs_crn
+  cluster_id            = local.cluster_id
+  vpc_name              = var.vpc_name
+  vpc_crn               = module.vpc_support.vpc_crn
+  setup_transit_gateway = var.setup_transit_gateway
+  transit_gateway_id    = module.vpc_support.transit_gateway_id
+  transit_gateway_name  = var.transit_gateway_name
+  powervs_crn           = module.pvs_prepare.powervs_crn
 }
 
 module "support" {

--- a/modules/1_vpc_support/3_existing_gateway/outputs.tf
+++ b/modules/1_vpc_support/3_existing_gateway/outputs.tf
@@ -6,3 +6,11 @@
 output "existing_tg" {
   value = data.ibm_tg_gateway.existing_tg.id
 }
+
+output "existing_tg_name" {
+  value = data.ibm_tg_gateway.existing_tg.name
+}
+
+output "existing_tg_status" {
+  value = data.ibm_tg_gateway.existing_tg.status
+}

--- a/modules/1_vpc_support/3_existing_gateway/transit_gateway.tf
+++ b/modules/1_vpc_support/3_existing_gateway/transit_gateway.tf
@@ -9,15 +9,7 @@
 
 # Loads the asserted transit gateway
 data "ibm_tg_gateway" "existing_tg" {
-  name = var.override_transit_gateway_name
-}
-
-# Dev Note: loads an existing transit gateway
-resource "ibm_tg_connection" "vpc_tg_connection_update" {
-  gateway      = data.ibm_tg_gateway.existing_tg.id
-  network_type = "vpc"
-  name         = "${var.vpc_name}-conn"
-  network_id   = var.resource_crn
+  name = var.transit_gateway_name
 }
 
 resource "ibm_resource_tag" "tag" {

--- a/modules/1_vpc_support/3_existing_gateway/variables.tf
+++ b/modules/1_vpc_support/3_existing_gateway/variables.tf
@@ -3,7 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 ################################################################
 
-variable "override_transit_gateway_name" {}
+variable "setup_transit_gateway" {}
+variable "transit_gateway_name" {}
 variable "resource_crn" {}
 variable "vpc_name" {}
 variable "mac_tags" {}

--- a/modules/1_vpc_support/3_transit_gateway/outputs.tf
+++ b/modules/1_vpc_support/3_transit_gateway/outputs.tf
@@ -6,3 +6,11 @@
 output "new_tg" {
   value = ibm_tg_gateway.mac_tg_gw.id
 }
+
+output "new_tg_name" {
+  value = ibm_tg_gateway.mac_tg_gw.name
+}
+
+output "new_tg_status" {
+  value = ibm_tg_gateway.mac_tg_gw.status
+}

--- a/modules/1_vpc_support/3_transit_gateway/variables.tf
+++ b/modules/1_vpc_support/3_transit_gateway/variables.tf
@@ -8,3 +8,4 @@ variable "vpc_name" {}
 variable "vpc_region" {}
 variable "resource_group" {}
 variable "mac_tags" {}
+variable "setup_transit_gateway" {}

--- a/modules/1_vpc_support/outputs.tf
+++ b/modules/1_vpc_support/outputs.tf
@@ -20,7 +20,7 @@ output "transit_gateway_id" {
 }
 
 output "transit_gateway_name" {
-  value = var.setup_transit_gateway == false ? module.existing_gateway[0].existing_tg_name : module.transit_gateway[0].new_tg_name
+  value = !var.setup_transit_gateway ? module.existing_gateway[0].existing_tg_name : module.transit_gateway[0].new_tg_name
 }
 
 output "transit_gateway_status" {

--- a/modules/1_vpc_support/outputs.tf
+++ b/modules/1_vpc_support/outputs.tf
@@ -16,5 +16,13 @@ output "vpc_crn" {
 }
 
 output "transit_gateway_id" {
-  value = var.override_transit_gateway_name == "" ? module.transit_gateway[0].new_tg : module.existing_gateway[0].existing_tg
+  value = var.setup_transit_gateway == true ? module.transit_gateway[0].new_tg : module.existing_gateway[0].existing_tg
+}
+
+output "transit_gateway_name" {
+  value = var.setup_transit_gateway == false ? module.existing_gateway[0].existing_tg_name : module.transit_gateway[0].new_tg_name
+}
+
+output "transit_gateway_status" {
+  value = var.setup_transit_gateway == false ? module.existing_gateway[0].existing_tg_status : module.transit_gateway[0].new_tg_status
 }

--- a/modules/1_vpc_support/outputs.tf
+++ b/modules/1_vpc_support/outputs.tf
@@ -24,5 +24,5 @@ output "transit_gateway_name" {
 }
 
 output "transit_gateway_status" {
-  value = var.setup_transit_gateway == false ? module.existing_gateway[0].existing_tg_status : module.transit_gateway[0].new_tg_status
+  value = !var.setup_transit_gateway ? module.existing_gateway[0].existing_tg_status : module.transit_gateway[0].new_tg_status
 }

--- a/modules/1_vpc_support/outputs.tf
+++ b/modules/1_vpc_support/outputs.tf
@@ -16,7 +16,7 @@ output "vpc_crn" {
 }
 
 output "transit_gateway_id" {
-  value = var.setup_transit_gateway == true ? module.transit_gateway[0].new_tg : module.existing_gateway[0].existing_tg
+  value = var.setup_transit_gateway ? module.transit_gateway[0].new_tg : module.existing_gateway[0].existing_tg
 }
 
 output "transit_gateway_name" {

--- a/modules/1_vpc_support/support.tf
+++ b/modules/1_vpc_support/support.tf
@@ -67,7 +67,7 @@ module "existing_gateway" {
 }
 
 module "transit_gateway" {
-  count = var.setup_transit_gateway != true ? 0 : 1
+  count = !var.setup_transit_gateway ? 0 : 1
 
   providers = {
     ibm = ibm

--- a/modules/1_vpc_support/support.tf
+++ b/modules/1_vpc_support/support.tf
@@ -52,32 +52,34 @@ module "security_groups" {
 }
 
 module "existing_gateway" {
-  count = var.override_transit_gateway_name != "" ? 1 : 0
+  count = var.setup_transit_gateway != true ? 1 : 0
 
   providers = {
     ibm = ibm
   }
   source = "./3_existing_gateway"
 
-  override_transit_gateway_name = var.override_transit_gateway_name
-  resource_crn                  = data.ibm_is_vpc.vpc.resource_crn
-  vpc_name                      = var.vpc_name
-  mac_tags                      = var.mac_tags
+  setup_transit_gateway = var.setup_transit_gateway
+  transit_gateway_name  = var.transit_gateway_name
+  resource_crn          = data.ibm_is_vpc.vpc.resource_crn
+  vpc_name              = var.vpc_name
+  mac_tags              = var.mac_tags
 }
 
 module "transit_gateway" {
-  count = var.override_transit_gateway_name != "" ? 0 : 1
+  count = var.setup_transit_gateway != true ? 0 : 1
 
   providers = {
     ibm = ibm
   }
   source = "./3_transit_gateway"
 
-  resource_crn   = data.ibm_is_vpc.vpc.resource_crn
-  vpc_name       = var.vpc_name
-  vpc_region     = var.vpc_region
-  resource_group = data.ibm_is_vpc.vpc.resource_group
-  mac_tags       = var.mac_tags
+  setup_transit_gateway = var.setup_transit_gateway
+  resource_crn          = data.ibm_is_vpc.vpc.resource_crn
+  vpc_name              = var.vpc_name
+  vpc_region            = var.vpc_region
+  resource_group        = data.ibm_is_vpc.vpc.resource_group
+  mac_tags              = var.mac_tags
 }
 
 module "vsi" {

--- a/modules/1_vpc_support/support.tf
+++ b/modules/1_vpc_support/support.tf
@@ -52,7 +52,7 @@ module "security_groups" {
 }
 
 module "existing_gateway" {
-  count = var.setup_transit_gateway != true ? 1 : 0
+  count = !var.setup_transit_gateway ? 1 : 0
 
   providers = {
     ibm = ibm

--- a/modules/1_vpc_support/variables.tf
+++ b/modules/1_vpc_support/variables.tf
@@ -60,6 +60,7 @@ variable "vpc_supp_public_ip" {
 }
 
 variable "powervs_machine_cidr" {}
-variable "override_transit_gateway_name" {}
+variable "setup_transit_gateway" {}
+variable "transit_gateway_name" {}
 variable "mac_tags" {}
 variable "skip_vpc_key" {}

--- a/modules/3_transit_gateway/transit_gateway.tf
+++ b/modules/3_transit_gateway/transit_gateway.tf
@@ -4,7 +4,7 @@
 ################################################################
 
 module "generated" {
-  count = var.setup_transit_gateway == true ? 1 : 0
+  count = var.setup_transit_gateway ? 1 : 0
   providers = {
     ibm = ibm
   }

--- a/modules/3_transit_gateway/transit_gateway.tf
+++ b/modules/3_transit_gateway/transit_gateway.tf
@@ -4,7 +4,7 @@
 ################################################################
 
 module "generated" {
-  count = var.override_transit_gateway_name == "" ? 1 : 0
+  count = var.setup_transit_gateway == true ? 1 : 0
   providers = {
     ibm = ibm
   }

--- a/modules/3_transit_gateway/variables.tf
+++ b/modules/3_transit_gateway/variables.tf
@@ -6,6 +6,7 @@
 variable "cluster_id" {}
 variable "vpc_name" {}
 variable "vpc_crn" {}
+variable "setup_transit_gateway" {}
 variable "transit_gateway_id" {}
-variable "override_transit_gateway_name" {}
+variable "transit_gateway_name" {}
 variable "powervs_crn" {}

--- a/outputs.tf
+++ b/outputs.tf
@@ -21,6 +21,16 @@ output "vpc_check_key" {
   value       = module.vpc_support.vpc_check_key
 }
 
+output "transit_gateway_name" {
+  description = "The name of the Transit Gateway"
+  value       = module.vpc_support.transit_gateway_name
+}
+
+output "transit_gateway_status" {
+  description = "The staus for the Transit Gateway"
+  value       = module.vpc_support.transit_gateway_status
+}
+
 output "bastion_private_interface" {
   value       = module.worker.bastion_private_ip
   description = "The interface mac and ip details"

--- a/variables.tf
+++ b/variables.tf
@@ -527,7 +527,13 @@ variable "keep_dns" {
 # PowerVS perspective.
 ################################################################
 
-variable "override_transit_gateway_name" {
+variable "setup_transit_gateway" {
+  type        = bool
+  description = "Flag to create the new transit gateway by automation"
+  default     = false
+}
+
+variable "transit_gateway_name" {
   type        = string
   description = "uses an existing transit gateway"
   default     = ""


### PR DESCRIPTION
setup_transit_gateway flag is added. It's default value false 

If setup_transit_gateway = false
User needs to manually create Transit Gateway , valid connections and pass it's name to 'transit_gateway_name' variable 

If setup_transit_gateway = true
Creation of Transit Gateway, it's connections will be taken care by automation. Also no need to specify 'transit_gateway_name' variable. Transit Gateway name will be constructed automatically based on VPC name. 