### PR TITLE
OPENSHIFTP-164: nfs-storage class name changes for cicd flag

### DIFF
--- a/ansible/support/templates/nfs-sc.yml
+++ b/ansible/support/templates/nfs-sc.yml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: nfs-storage
+  name: {{ "auto-nfs-storage" if cicd|lower == "true" else "nfs-storage" }}
   annotations:
     storageclass.kubernetes.io/is-default-class: "true"
 provisioner: k8s-sigs.io/nfs-subdir-external-provisioner

--- a/main.tf
+++ b/main.tf
@@ -153,6 +153,7 @@ module "support" {
   nfs_server               = module.vpc_support.vpc_support_server_ip
   nfs_path                 = var.nfs_path
   cluster_network_mtu      = var.cluster_network_mtu
+  cicd                     = var.cicd
 }
 
 module "worker" {

--- a/modules/4_pvs_support/pvs_support.tf
+++ b/modules/4_pvs_support/pvs_support.tf
@@ -27,6 +27,7 @@ locals {
     gateway                      = cidrhost(var.powervs_machine_cidr, 1)
     nfs_server                   = var.nfs_server
     nfs_path                     = var.nfs_path
+    cicd                         = var.cicd
   }
 
   cidrs = {

--- a/modules/4_pvs_support/templates/vars.yaml.tpl
+++ b/modules/4_pvs_support/templates/vars.yaml.tpl
@@ -1,4 +1,5 @@
 ---
+cicd: "${cicd}"
 ocp_client: "${client_tarball}"
 openshift_machine_config_url: "${openshift_machine_config_url}:22623/config/worker"
 vpc_support_server_ip: "${vpc_support_server_ip}"

--- a/modules/4_pvs_support/variables.tf
+++ b/modules/4_pvs_support/variables.tf
@@ -20,6 +20,7 @@ variable "keep_dns" {}
 variable "nfs_server" {}
 variable "nfs_path" {}
 variable "cluster_network_mtu" {}
+variable "cicd" {}
 variable "worker" {
   type = object({ count = number, memory = string, processors = string })
   default = {


### PR DESCRIPTION
Code changes are made to support following behavior

In var.tfvars file 
if cicd  = true then nfs storage class will be created with name "auto-nfs-storage"
if cicd = false then nfs storage class will be created with name "nfs-storage"

Kindly review and merge changes.