### PR TITLE
OPENSHIFTP-188: disable etcd defragmentation using flag cicd_disable_defrag

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -154,6 +154,7 @@ module "support" {
   nfs_path                 = var.nfs_path
   cluster_network_mtu      = var.cluster_network_mtu
   cicd                     = var.cicd
+  cicd_disable_defrag      = var.cicd_disable_defrag
 }
 
 module "worker" {

--- a/modules/4_pvs_support/variables.tf
+++ b/modules/4_pvs_support/variables.tf
@@ -21,6 +21,7 @@ variable "nfs_server" {}
 variable "nfs_path" {}
 variable "cluster_network_mtu" {}
 variable "cicd" {}
+variable "cicd_disable_defrag" {}
 variable "worker" {
   type = object({ count = number, memory = string, processors = string })
   default = {

--- a/variables.tf
+++ b/variables.tf
@@ -527,6 +527,13 @@ variable "keep_dns" {
   default     = false
 }
 
+variable "cicd_disable_defrag" {
+  type        = bool
+  description = "Creates a config map 'etcd-disable-defrag' to disable the etcd defragmentation"
+  default     = false
+  # User needs to manually remove the config map to restore the settings
+}
+
 ################################################################
 # Overrides the dhcp network, transit gateway creation from a 
 # PowerVS perspective.


### PR DESCRIPTION
Disabled etcd defragmentation based on flag cicd_disable_defrag.

Default value for cicd_disable_defrag is false. 
When it is set to true then configmap 'etcd-disable-defrag' is created in namespace 'openshift-etcd-operator' [If said config map is not available]